### PR TITLE
Update modify.spec.js

### DIFF
--- a/src/modify.spec.js
+++ b/src/modify.spec.js
@@ -32,8 +32,8 @@ describe(testSuiteName, () => {
   it('destructureCoordinates - Destructures the coordinates array into x and y variables', () => {
     const textContent = destructureCoordinates.toString();
 
-    expect(textContent).not.toMatch(/const x/);
-    expect(textContent).not.toMatch(/const y/);
+    expect(textContent).not.toMatch(/\nconst x/);
+    expect(textContent).not.toMatch(/\nconst y/);
     expect(textContent).toMatch(/`X is: \${x}, Y is: \${y}`/);
 
     const result1 = destructureCoordinates([1, 2]);


### PR DESCRIPTION
Adding in a new line check before `const`. A student who comments out the code will fail the original tests because their code will still contain `const x`, matching the string `"// const x"`

For example:

```js
const destructureCoordinates = ([x, y]) => {
  //const x = coordinates[0]; instead of using coordinates parameter use just x and y
  //const y = coordinates[1];
  // const [x,y] = coordinates;
  return `X is: ${x}, Y is: ${y}`; // no touching this line!
};
```